### PR TITLE
Fix issue #6

### DIFF
--- a/examples/example_05_syscall_trace.rs
+++ b/examples/example_05_syscall_trace.rs
@@ -1,4 +1,4 @@
-use std::{fs, thread::sleep, time::Duration};
+use std::fs;
 
 use restrict::{
     policy::{self, Policy, Syscall},
@@ -9,6 +9,7 @@ fn main() -> Result<(), SeccompError> {
     let mut policy = Policy::allow_all()?;
     policy.deny(Syscall::Munmap);
     policy.deny(Syscall::ExitGroup);
+    // policy.allow(Syscall::ExitGroup);
     // policy.deny(Syscall::Write)?;
     policy.trace(policy::Syscall::Openat, |syscall| {
         println!("Syscall {:?} triggered", syscall);
@@ -19,6 +20,6 @@ fn main() -> Result<(), SeccompError> {
     policy.apply()?;
     let open_file = fs::File::open("test.txt");
     println!("Opened file {:?}", open_file);
-    sleep(Duration::from_secs(5));
+    // sleep(Duration::from_secs(5));
     Ok(())
 }

--- a/examples/example_07_command.rs
+++ b/examples/example_07_command.rs
@@ -1,0 +1,41 @@
+use std::{
+    os::unix::process::{CommandExt, ExitStatusExt},
+    process::Command,
+};
+
+use restrict::{
+    policy::{Policy, Syscall},
+    SeccompError, TraceAction,
+};
+
+fn main() -> Result<(), SeccompError> {
+    let mut child = unsafe {
+        println!("> Running ls");
+        Command::new("ls")
+            .pre_exec(|| {
+                let mut policy = Policy::allow_all().unwrap();
+                policy
+                    .trace(Syscall::Openat, |syscall| {
+                        println!("Syscall {:?} triggered ", syscall);
+                        return TraceAction::Continue;
+                    })
+                    .trace(Syscall::Read, |syscall| {
+                        println!("Syscall {:?} triggered ", syscall);
+                        return TraceAction::Continue;
+                    });
+                policy.apply().unwrap();
+                Ok(())
+            })
+            .spawn()
+            .expect("Failed to start process")
+    };
+
+    let status = child.wait().expect("Failed to wait on process");
+    if let Some(signal) = status.signal() {
+        println!("Child killed by signal: {}", signal);
+    } else {
+        println!("Child exited normally: {}", status);
+    }
+    println!("Child exited with status: {status}");
+    Ok(())
+}

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -154,7 +154,9 @@ impl Policy {
                     let mapped_tracers = TracerMap::from(trace_r);
 
                     if self.verbose {
-                        println!("[Parent-process]: Listening to incoming syscalls");
+                        println!(
+                            "[Parent-process]: Listening to incoming syscalls from {child_pid}"
+                        );
                     }
                     PtraceWrapper::with_pid(child_pid).event_loop(mapped_tracers)?;
 


### PR DESCRIPTION
Removing the deprecated PTRACE_KILL.
Killing through kill(SIGKILL) directly and using ptrace_kill as a fallback.
Resolves #6.