### PR TITLE
[feature] Disable io-uring bypass

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -72,6 +72,12 @@ impl Policy {
             .push(seccomp::SeccompFilter::new(syscall, Action::Kill));
         self
     }
+    /// disable io-uring bypass
+    pub fn disable_iouring_bypass(&mut self) -> &mut Self {
+        self.deny(Syscall::IoUringEnter)
+            .deny(Syscall::IoUringSetup)
+            .deny(Syscall::IoUringRegister)
+    }
     /// apply
     pub fn apply(&mut self) -> Result<(), SeccompError> {
         let mut context = self.context.take().ok_or(SeccompError::Fork)?;


### PR DESCRIPTION
### Disable io-uring:
this PR gives the option to disable io-uring bypasses by disallowing the following syscalls:
```
io_uring_enter()
io_uring_setup()
io_uring_register()
```


Fixes #10.